### PR TITLE
Fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --watchAll=false & yarn test:coverage & yarn lint",
+    "test": "react-scripts test --coverage --watchAll=false & yarn lint",
     "test:ci": "react-scripts test --verbose --coverage --collectCoverageFrom=\"src/**/*.{js,jsx,ts,tsx}\" --coverageDirectory reports --maxWorkers=2",
     "test:watch": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --runInBand --watchAll=false",


### PR DESCRIPTION
The `yarn test` command was running the test function twice because it was also calling the coverage script. This changes it to pass coverage parameter in the test command.