### PR TITLE
Add warn setting for style errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,11 @@ module.exports = {
     'jest/prefer-to-have-length': 'warn',
     'jest/valid-expect': 'error',
     'react/prop-types': 'off',
-    'no-unused-vars': 'warn'
+    'indent': 'warn',
+    'no-unused-vars': 'warn',
+    'no-trailing-spaces': 'warn',
+    'no-multiple-empty-lines': 'warn',
+    'no-unreachable': 'warn'
   },
   settings: {
     react: {


### PR DESCRIPTION
Added common development style errors to the warn list. These styling issues should not be in production, but they shouldn't break the development process.

Resolves #9 